### PR TITLE
fix room join for freenode channels

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -61,7 +61,9 @@ class IrcBot extends Adapter
       bot.addListener 'notice', (from, to, text) ->
         if from is 'NickServ' and text.indexOf('registered') isnt -1
           bot.say 'NickServ', "identify #{options.nickpass}"
-        else if options.nickpass and from is 'NickServ' and text.indexOf('Password accepted') isnt -1
+        else if options.nickpass and from is 'NickServ' and
+                (text.indexOf('Password accepted') isnt -1 or
+                 text.indexOf('identified') isnt -1)
           for room in options.rooms
             @join room
 


### PR DESCRIPTION
I had this problem that hubot wouldn't join rooms and just idled connected to
the freenode servers. I tracked it down to the `NOTICE` message parsing. The
freenode servers would not send 'Password accepted' but rather something like
'You are now identified for ...'. I added a condition to take that into
account.

I am not sure if this is the best way to manage it as I don't have this problem on other IRC servers, which apparently also don't send "Password accepted."

Related to issue #1
