### PR TITLE
Add "name: " in private message sent directly to the bot

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -71,7 +71,7 @@ class IrcBot extends Adapter
 
     bot.addListener 'message', (from, to, message) ->
       console.log "From #{from} to #{to}: #{message}"
-      
+
       user = self.userForName from
       unless user?
         id = (new Date().getTime() / 1000).toString().replace('.','')
@@ -83,6 +83,8 @@ class IrcBot extends Adapter
         console.log "#{to} <#{from}> #{message}"
       else
         user.room = null
+        unless message.indexOf(to) == 0
+          message = "#{to}: #{message}"
         console.log "msg <#{from}> #{message}"
 
       self.receive new Robot.TextMessage(user, message)


### PR DESCRIPTION
When I send private message directly to the bot (via /msg or /query), it is tedious to add the bot name again. This trick allows `respond` handle those direct private messages without name prefix.
