### PR TITLE
allow for better user identification for some IRC networks

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -42,9 +42,10 @@ class IrcBot extends Adapter
       unflood:  process.env.HUBOT_IRC_UNFLOOD?
       debug:    process.env.HUBOT_IRC_DEBUG?
       usessl:   process.env.HUBOT_IRC_USESSL?
+      userName: process.env.HUBOT_IRC_USERNAME?
 
     client_options =
-      userName: process.env.HUBOT_IRC_USERNAME
+      userName: options.userName,
       password: options.password,
       debug: options.debug,
       port: options.port,


### PR DESCRIPTION
hi guys,

I added a new environment variable that allows you to control the user part of the user@host string that hubot reports to the IRC server. some IRC servers, for example our internal one, check the user part to see if it is a valid user, might enforce the same user and nickname, etc. this patch allows us to use hubot in our IRC network and I hope others can benefit from it as well.

i am new to github and coffeescript, so any feedback is greatly appreciated. :-)

thanks,
fabian
