### PR TITLE
Robot connected event is not emitted from latest Hubot

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -108,6 +108,8 @@ class IrcBot extends Adapter
 
     @bot = bot
 
+    self.emit "connected"
+
 exports.use = (robot) ->
   new IrcBot robot
 


### PR DESCRIPTION
It appears, since github/hubot@93e85528c8 that scripts will not be loaded until a "connected" event is received. 
 As a result, hubot with the irc adapter will appear to be unresponsive. 

The resolution was to add robot.emit "connected" to robot.run

Signed-off-by: Ian Anderson getfatday@gmail.com
