### PR TITLE
Add support for robot.enter and robot.leave

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -91,7 +91,7 @@ class IrcBot extends Adapter
             @join room
 
     bot.addListener 'message', (from, to, message) ->
-      #console.log "From #{from} to #{to}: #{message}"
+      console.log "From #{from} to #{to}: #{message}"
       
       user = self.userForName from
       unless user?


### PR DESCRIPTION
robot.enter and robot.leave are two triggers in hubot that are supposed to fire whenever someone enters or leaves the room. This functionality is not yet added in the irc adapter.

The relevant changes are the additions to the various bot.addListener functions (join, part, kick, quit)

I'm new to coffeescript (and to github in general) so I merely copied and modified the code from the "message" listener. There's probably a better/more efficient way to do this but I'm not the person to figure it out.

I tested on my own hubot instance and confirmed it's working though.
