### PR TITLE
Hubot dependancies fix

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -1,5 +1,5 @@
-Robot   = require('hubot').robot()
-Adapter = require('hubot').adapter()
+Robot   = require("#{__dirname}/../../../").robot()
+Adapter = require("#{__dirname}/../../../").adapter()
 
 Irc     = require 'irc'
 


### PR DESCRIPTION
This removes the need to add hubot as a dependency for the hubot-irc adapter.

Rather than adding the installed hubot version as a subordinate node module to hubot-irc, we can use the `__dirname` global node variable to ensure that we travel back up through out the folder structure from the hubot-irc directory and utilize the parent hubot installation.
### Missing 'hubot'

This was partially in response to my initial misunderstanding in Issue https://github.com/nandub/hubot-irc/issues/27
### Hubot "silent"

This also seems to fix the issue of hubot being silent at some points. This stops me from having to add my "temporary fix" to robot.coffee in hubot src. https://github.com/nandub/hubot-irc/issues/2
