### PR TITLE
Optional username for NickServ `identify`

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -127,7 +127,7 @@ class IrcBot extends Adapter
       identify_args += "#{options.nickpass}"
 
       bot.addListener 'notice', (from, to, text) ->
-        if from is 'NickServ' and text.indexOf('registered') isnt -1
+        if from is 'NickServ' and text.indexOf('identify') isnt -1
           bot.say 'NickServ', "identify #{identify_args}"
         else if options.nickpass and from is 'NickServ' and
                 (text.indexOf('Password accepted') isnt -1 or


### PR DESCRIPTION
For certain IRC services (namely Flowdock), users are required to pass `<email> <password>` to identify instead of just a password. This PR introduces new env variable, `HUBOT_IRC_NICKSERV_USERNAME` to facilitate the use of these services.

Also, I changed the `identify` listener to listen for notices from NickServ containing `identify` instead of `registered`, since it is more generic (and `registered` wasn't working with Flowdock).
