### PR TITLE
Tweaked user ID generation.

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -54,7 +54,7 @@ class IrcBot extends Adapter
   createUser: (channel, from) ->
       user = @userForName from
       unless user?
-        id = (new Date().getTime() / 1000).toString().replace('.','')
+        id = new Date().getTime().toString()
         user = @userForId id
         user.name = from
 


### PR DESCRIPTION
Removed the silly /1000 and decimal replacement thing from the user ID generation.

Trivia: Given that we're in the 13 digit era, this change only increases the memory used for user IDs by less than 1%.
