### PR TITLE
Undelete extended Response

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -8,6 +8,14 @@ Response = require('hubot').Response
 Irc     = require 'irc'
 
 class IrcBot extends Adapter
+  constructor: (@robot) ->
+    super @robot
+
+    @robot.notice = (user, strings...) ->
+      @adapter.notice user, strings...
+
+    @robot.Response = IrcResponse
+
   send: (user, strings...) ->
     for str in strings
       if not str?


### PR DESCRIPTION
Extended Response (IrcResponse) was deleted by below commit.

https://github.com/nandub/hubot-irc/commit/a54b89d8589be616e8498404713c77549836bc0d

But I think this extension can be used on latest hubot(,and I want to use notice message on hubot-irc).

So, I Undelete extending Response process.

It would be nice if you could merge.
