### PR TITLE
Update package.json to install node-irc 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "./src/irc.coffee",
   "engine": "node > 0.6.0 < 0.8.0",
   "dependencies": {
-    "irc": "0.3.4"
+    "irc": "0.3.5"
   },
   "devDependencies": {
     "coffee-script": "1.1.3"


### PR DESCRIPTION
0.3.5 has been tagged about a month ago and includes some fixes that I want to use for a specific IRC server in place.  Been running a fork, but would be nice to bring this in.
