### PR TITLE
Handle PMs once, rather than twice.

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -165,6 +165,10 @@ class IrcBot extends Adapter
         self.createUser channel, nick
 
     bot.addListener 'message', (from, to, message) ->
+      if options.nick.toLowerCase() == to.toLowerCase()
+        # this is a private message, let the 'pm' listener handle it
+        return
+
       console.log "From #{from} to #{to}: #{message}"
 
       user = self.createUser to, from


### PR DESCRIPTION
Currently new PMs are handled first by the 'message' handler and then by the
'pm' handler.  This change makes the 'message' handler take a back seat to the
'pm' handler.
