### PR TITLE
Clear user.room when a user leaves the channel

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -200,7 +200,7 @@ class IrcBot extends Adapter
 
     bot.addListener 'part', (channel, who, reason) ->
       console.log('%s has left %s: %s', who, channel, reason)
-      user = self.createUser channel, who
+      user = self.createUser '', who
       self.receive new LeaveMessage(user)
 
     bot.addListener 'kick', (channel, who, _by, reason) ->


### PR DESCRIPTION
I think this is the intention of the createUser method, but the channel is always passed as a parameter so is never set to null.
