### PR TITLE
Considerations for private bots

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -187,6 +187,9 @@ class IrcBot extends Adapter
 
     bot.addListener 'pm', (nick, message) ->
       console.log('Got private message from %s: %s', nick, message)
+      
+      if process.env.HUBOT_IRC_PRIVATE
+        return
 
       nameLength = options.nick.length
       if message.slice(0, nameLength).toLowerCase() != options.nick.toLowerCase()
@@ -209,7 +212,9 @@ class IrcBot extends Adapter
 
     bot.addListener 'invite', (channel, from) ->
       console.log('%s invite you to join %s', from, channel)
-      bot.join channel
+      
+      if not process.env.HUBOT_IRC_PRIVATE
+        bot.join channel
 
     @bot = bot
 


### PR DESCRIPTION
If I run my bot in a public place, like freenode, I want to be able to control exactly what rooms it joins.

Just walking into any room someone invites him into and talking with strangers is bad :)
