### PR TITLE
Fix typo

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -69,7 +69,7 @@ class IrcBot extends Adapter
       user = @getUserFromName from
       unless user?
         id = new Date().getTime().toString()
-        user = @getUserForId id
+        user = @getUserFromId id
         user.name = from
 
       if channel.match(/^[&#]/)


### PR DESCRIPTION
based on error:

2013-06-14T21:50:16.221178+00:00 app[web.1]: 14 Jun 21:50:16 - SEND: JOIN #deafhack
2013-06-14T21:50:16.221371+00:00 app[web.1]: 14 Jun 21:50:16 - MODE:GODbot sets mode: +Zi2013-06-14T21:50:22.636089+00:00 app[web.1]: GODbot has joined #deafhack2013-06-14T21:50:22.636729+00:00 app[web.1]: 2013-06-14T21:50:22.637130+00:00 app[web.1]: /app/node_modules/hubot-irc/node_modules/irc/lib/irc.js:6372013-06-14T21:50:22.637437+00:00 app[web.1]:                     throw err;2013-06-14T21:50:22.637725+00:00 app[web.1]:                           ^2013-06-14T21:50:22.645169+00:00 app[web.1]: TypeError: Object #<IrcBot> has no method 'getUserForId'2013-06-14T21:50:22.645169+00:00 app[web.1]:   at IrcBot.createUser (/app/node_modules/hubot-irc/src/irc.coffee:122:21)2013-06-14T21:50:22.645169+00:00 app[web.1]:   at Client.<anonymous> (/app/node_modules/hubot-irc/src/irc.coffee:299:21)2013-06-14T21:50:22.645169+00:00 app[web.1]:   at Client.EventEmitter.emit (events.js:106:17)2013-06-14T21:50:22.645169+00:00 app[web.1]:   at Client.<anonymous> (/app/node_modules/hubot-irc/node_modules/irc/lib/irc.js:414:22)2013-06-14T21:50:22.645169+00:00 app[web.1]:   at Client.EventEmitter.emit (events.js:95:17)2013-06-14T21:50:22.645169+00:00 app[web.1]:   at /app/node_modules/hubot-irc/node_modules/irc/lib/irc.js:634:22
2013-06-14T21:50:22.645169+00:00 app[web.1]:   at Array.forEach (native)
2013-06-14T21:50:22.645169+00:00 app[web.1]:   at CleartextStream.<anonymous> (/app/node_modules/hubot-irc/node_modules/irc/lib/irc.js:631:15)
2013-06-14T21:50:22.645169+00:00 app[web.1]:   at CleartextStream.EventEmitter.emit (events.js:95:17)
2013-06-14T21:50:22.645364+00:00 app[web.1]:   at CleartextStream.<anonymous> (_stream_readable.js:736:14)
2013-06-14T21:50:22.645364+00:00 app[web.1]:   at CleartextStream.EventEmitter.emit (events.js:92:17)
2013-06-14T21:50:22.645364+00:00 app[web.1]:   at emitReadable_ (_stream_readable.js:408:10)
2013-06-14T21:50:22.645364+00:00 app[web.1]:   at _stream_readable.js:401:7
2013-06-14T21:50:22.645364+00:00 app[web.1]:   at process._tickCallback (node.js:415:13)
2013-06-14T21:50:22.645364+00:00 app[web.1]:
2013-06-14T21:50:23.954866+00:00 heroku[web.1]: Process exited with status 8
2013-06-14T21:50:23.968402+00:00 heroku[web.1]: State changed from up to crashed
