### PR TITLE
Updates README to include reference to HUBOT_IRC_PRIVATE env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ variable to anything.
 This is the optional flag if your hubot is connecting to an IRC server using
 SSL. You can set the variable to anything.
 
+### IRC Private
+
+This is the optional flag if your hubot should ignore `PRIVMSG` and `INVITE`
+commands. You can set the variable to anything.
+
 ### Configuring the variables on Heroku
 
     % heroku config:add HUBOT_IRC_SERVER="..."


### PR DESCRIPTION
Had to look through the code for this one, so I figured there could be a hint. Based on my reading, this variable being set to `true` prevents:
- Hubot from responding to PRIVMSG commands
- Hubot from accepting `/invite #channel` commands automatically
