### PR TITLE
Pass user to Leave and Enter Message constructors

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -58,14 +58,16 @@ class IrcBot extends Adapter
     @bot.join channel, () ->
       console.log('joined %s', channel)
 
-      self.receive new EnterMessage(null)
+      selfUser = self.getUserFromName self.robot.name
+      self.receive new EnterMessage(selfUser)
 
   part: (channel) ->
     self = @
     @bot.part channel, () ->
       console.log('left %s', channel)
 
-      self.receive new LeaveMessage(null)
+      selfUser = self.getUserFromName self.robot.name
+      self.receive new LeaveMessage(selfUser)
 
   getUserFromName: (name) ->
     return @robot.brain.userForName(name) if @robot.brain?.userForName?


### PR DESCRIPTION
If you try to call the `join` or `part` messages they throw an error because the constructors for `EnterMessage` and `LeaveMessage` are both expecting a `@user` (inherited from `Message` class). In more recent versions of hubot, the Message constructor is expecting the `@user` parameter to have a `.room` property.

This code attempts to get a user with the same name as your hubot and passes it to the constructors.
