### PR TITLE
Use npm version of irc

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "irc": "git://github.com/nandub/node-irc.git"
+    "irc": "git+https://github.com/nandub/node-irc.git"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
When I try to install this behind the firewall, the `git://` protocol version can't be installed by npm. I tried the `irc` version in npm and it works fine, any reason to use your fork?
