### PR TITLE
Add support for distinguishing emotes from regular actions

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -1,5 +1,5 @@
 # Hubot dependencies
-{Robot, Adapter, TextMessage, EnterMessage, LeaveMessage, Response} = require 'hubot'
+{Robot, Adapter, TextMessage, EmoteMessage, EnterMessage, LeaveMessage, Response} = require 'hubot'
 
 # Irc library
 Irc = require 'irc'
@@ -233,7 +233,7 @@ class IrcBot extends Adapter
       else
         console.log "msg <#{from}> #{message}"
 
-      self.receive new TextMessage(user, message)
+      self.receive new EmoteMessage(user, message)
 
     bot.addListener 'error', (message) ->
       console.error('ERROR: %s: %s', message.command, message.args.join(' '))


### PR DESCRIPTION
I'm not sure this solution fits in the hubot-irc core, as it disrupts
how people would currently use hubot-irc to track regular messages and
ACTION messages together. If people relied receiving both as
TextMessages, people will stop receiving emotes in their listners. That
said, it feels right as a solution. That, or simply adding a property
that denotes that the TextMessage object is an emote.

https://gist.github.com/jasonmay/663901032394dea7ac25 is an example hubot script that tests it.
