### PR TITLE
Add HUBOT_IRC_IGNORE_NOTICE option

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -198,6 +198,8 @@ class IrcBot extends Adapter
         self.createUser channel, nick
 
     bot.addListener 'notice', (from, to, message) ->
+      return if process.env.HUBOT_IRC_IGNORE_NOTICE?
+
       if from in options.ignoreUsers
         console.log('Ignoring user: %s', from)
         # we'll ignore this message if it's from someone we want to ignore
@@ -288,7 +290,7 @@ class IrcBot extends Adapter
         console.log('Ignoring user: %s', from)
         # we'll ignore this message if it's from someone we want to ignore
         return
-      
+
       if not process.env.HUBOT_IRC_PRIVATE or process.env.HUBOT_IRC_IGNOREINVITE
         bot.join channel
 


### PR DESCRIPTION
Hi, I think there are a case that hubot-irc should not listen NOTICE. Because, it may happen a problem like the following.

```
  [PRVMSG] me: show me the title of http:example.com!
  [NOTICE] hubot: Title: This is http:example.com
  [NOTICE] hubot: Title: This is http:example.com
  [NOTICE] hubot: Title: This is http:example.com
  [NOTICE] hubot: Title: This is http:example.com
  endless...
```

And, RFC says:

https://tools.ietf.org/html/rfc2812#section-3.3.2

>   The NOTICE command is used similarly to PRIVMSG.  The difference
>   between NOTICE and PRIVMSG is that automatic replies MUST NEVER be
>   sent in response to a NOTICE message.  This rule applies to servers
>   too - they MUST NOT send any error reply back to the client on
>   receipt of a notice.  The object of this rule is to avoid loops
>   between clients automatically sending something in response to
>   something it received.

So, I add `HUBOT_IRC_LISTEN_NOTICE` option. Could you review it? Thanks.
