### PR TITLE
Save username for both user.name and user.id

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -77,19 +77,19 @@ class IrcBot extends Adapter
   getUserFromName: (name) ->
     return @robot.brain.userForName(name) if @robot.brain?.userForName?
 
+    # Deprecated in 3.0.0
     return @userForName name
 
   getUserFromId: (id) ->
+    # TODO: Add logic to convert object if name matches
     return @robot.brain.userForId(id) if @robot.brain?.userForId?
 
+    # Deprecated in 3.0.0
     return @userForId id
 
   createUser: (channel, from) ->
-    user = @getUserFromName from
-    unless user?
-      id = new Date().getTime().toString()
-      user = @getUserFromId id
-      user.name = from
+    user = @getUserFromId from
+    user.name = from
 
     if channel.match(/^[&#]/)
       user.room = channel


### PR DESCRIPTION
We're currently saving the irc nick as `user.name` and using the unix time of the first user sighting as the `user.id`. Authentication with auth.coffee assumes that `user.id` is unique in hubot's brain, and something that someone can store in the `HUBOT_ADMIN_USERS` envvar.

**I think IRC nick is the best `user.id` we have, and we should use that.** Yes, it isn't always unique, but we need to assume so in order to get hubot-irc working with auth.coffee. The actual auth will happen when a privileged command is called, so if the person isn't identified with nickserv, that service will let us know at that time.

Any objection? As far as I can tell, the timestamp doesn't really accomplish anything except ensuring that there's never a user id collision (which is unlikely because we're talking seconds, but it's technically just as inappropriate as using UTC rounded to the hour or minute :)

Thoughts?

Related: #103 
