### PR TITLE
Making sure we join rooms even if we don't have a nickserv password set

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -209,8 +209,10 @@ class IrcBot extends Adapter
           for room in options.rooms
             @join room
     else
-      for room in options.rooms
-        @join room
+      bot.addListener 'registered', (message) ->
+        # The 'registered' event is fired when you are connected to the server
+        for room in options.rooms
+          @join room
 
     if options.connectCommand?
       bot.addListener 'registered', (message) ->

--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -208,6 +208,9 @@ class IrcBot extends Adapter
                  text.indexOf('identified') isnt -1)
           for room in options.rooms
             @join room
+    else
+      for room in options.rooms
+        @join room
 
     if options.connectCommand?
       bot.addListener 'registered', (message) ->


### PR DESCRIPTION
It looks like when you aren't using a registered nickname, hubot-irc will never attempt to join the channels you setup. This just makes sure that we join channels even if we're not using NickServ.

I'm very new to node/coffee/etc so if this is not a good way of attempting this fix please let me know!