### PR TITLE
Don't enable done flag with text.

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -300,14 +300,18 @@ class IrcBot extends Adapter
       logger.info('%s has left %s: %s', who, channel, reason)
       user = self.createUser '', who
       user.room = channel
-      self.receive new LeaveMessage(user, reason)
+      msg = new LeaveMessage user
+      msg.text = reason
+      self.receive msg
 
     bot.addListener 'quit', (who, reason, channels) ->
       logger.info '%s has quit: %s (%s)', who, channels, reason
       for ch in channels
         user = self.createUser '', who
         user.room = ch
-        self.receive new LeaveMessage(user, reason)
+        msg = new LeaveMessage user
+        msg.text = reason
+        self.receive msg
 
     bot.addListener 'kick', (channel, who, _by, reason) ->
       logger.info('%s was kicked from %s by %s: %s', who, channel, _by, reason)


### PR DESCRIPTION
I thought `LeaveMessage` inherits `TextMessage` but its base was actually `Message`.
So `text` must be set manually after creating leave message.
