### PR TITLE
Log all hubot output to debug log?

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -23,6 +23,7 @@ class IrcBot extends Adapter
       return logger.error "ERROR: Not sure who to send to. envelope=", envelope
 
     for str in strings
+      logger.debug "#{target} #{str}"
       @bot.say target, str
 
   sendPrivate: (envelope, strings...) ->


### PR DESCRIPTION
I was hoping to build something on top of hubot's log (a twitter integration) and I noticed that while hubot's logging everything he hears he's not logging everything he says.  If he were logging his own .send() text then I could very easily hook into that.  What do you think?

cc @joshwlewis

btw thanks for this library from [#memtech on freenode](https://github.com/memtech/memtech-hubot) :beer: