### PR TITLE
Allow robot name that differs from irc nick

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -191,7 +191,7 @@ class IrcBot extends Adapter
     @robot.name = options.nick
     if process.env.HUBOT_IRC_ROBOT_NAME
       @robot.name = process.env.HUBOT_IRC_ROBOT_NAME
-      
+    robot_name = @robot.name # We need to keep the name in scope for callbacks that need it
     bot = new Irc.Client options.server, options.nick, client_options
 
     next_id = 1
@@ -289,9 +289,9 @@ class IrcBot extends Adapter
         # we'll ignore this message if it's from someone we want to ignore
         return
 
-      nameLength = @robot.name.length
-      if message.slice(0, nameLength).toLowerCase() != @robot.name.toLowerCase()
-        message = "#{@robot.name} #{message}"
+      nameLength = robot_name.length
+      if message.slice(0, nameLength).toLowerCase() != robot_name.toLowerCase()
+        message = "#{robot_name} #{message}"
 
       self.receive new TextMessage({reply_to: nick, name: nick}, message)
 

--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -189,6 +189,9 @@ class IrcBot extends Adapter
     @robot.Response = IrcResponse
 
     @robot.name = options.nick
+    if process.env.HUBOT_IRC_ROBOT_NAME
+      @robot.name = process.env.HUBOT_IRC_ROBOT_NAME
+      
     bot = new Irc.Client options.server, options.nick, client_options
 
     next_id = 1

--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -289,9 +289,9 @@ class IrcBot extends Adapter
         # we'll ignore this message if it's from someone we want to ignore
         return
 
-      nameLength = options.nick.length
-      if message.slice(0, nameLength).toLowerCase() != options.nick.toLowerCase()
-        message = "#{options.nick} #{message}"
+      nameLength = @robot.name
+      if message.slice(0, nameLength).toLowerCase() != @robot.name.toLowerCase()
+        message = "#{@robot.name} #{message}"
 
       self.receive new TextMessage({reply_to: nick, name: nick}, message)
 

--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -289,7 +289,7 @@ class IrcBot extends Adapter
         # we'll ignore this message if it's from someone we want to ignore
         return
 
-      nameLength = @robot.name
+      nameLength = @robot.name.length
       if message.slice(0, nameLength).toLowerCase() != @robot.name.toLowerCase()
         message = "#{@robot.name} #{message}"
 


### PR DESCRIPTION
Adds an envar HUBOT_IRC_ROBOT_NAME that will override the default hubot-irc of setting the robot name to the IRC nick.  Especially useful if you want your robot to be invoked  via a symbol (`!ping`). Fixes #132 
