### PR TITLE
emit a leavemessage on kick event

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -317,6 +317,11 @@ class IrcBot extends Adapter
 
     bot.addListener 'kick', (channel, who, _by, reason) ->
       logger.info('%s was kicked from %s by %s: %s', who, channel, _by, reason)
+      user = self.createUser '', who
+      user.room = channel
+      msg = new LeaveMessage user
+      msg.text = reason
+      self.receive msg
 
     bot.addListener 'invite', (channel, from) ->
       logger.info('%s invited you to join %s', from, channel)


### PR DESCRIPTION
a 'part' or 'quit' event is not emitted when a user is kicked, so i just replicated the logic from similar listeners.

without this, my irc bot isn't able to purge users that are no longer present from its memory. when i say 'memory', i don't mean robot.brain but rather the data-structure my bot creates, itself.

i'm not sure if i've gone about this the right way. also, i'm not even sure if this is entirely necessary. perhaps it's _already_ possible to catch a 'kick' event. if it is, please accept my apologies. :P