### PR TITLE
Log room messages at the debug level

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -248,7 +248,7 @@ class IrcBot extends Adapter
 
       user = self.createUser to, from
       if user.room
-        logger.info "#{to} <#{from}> #{message}"
+        logger.debug "#{to} <#{from}> #{message}"
       else
         unless message.indexOf(to) == 0
           message = "#{to}: #{message}"


### PR DESCRIPTION
It looks like in this singular case, room logs are logged at the info level.  In the default hubot configuration, channel logs are ending up in the hubot log, which may not be desired from a privacy standpoint unless explicitly enabled by changing the log level.