### PR TITLE
Node 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4"
   - "0.11"
   - "0.10"
   - "0.8"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "irc": "0.3.9",
+    "irc": "^0.4.0",
     "log": "1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`node-irc 0.3.9` requires `node-icu-charset-detector 0.0.7`, which does not compile with node 4.x. Let's update node-irc to 0.4.0 to be compatible with node 4.x