### PR TITLE
Add ! to channel.match regex

### DIFF
--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -113,7 +113,7 @@ class IrcBot extends Adapter
     user = @getUserFromId from
     user.name = from
 
-    if channel.match(/^[&#]/)
+    if channel.match(/^[&#\!]/)
       user.room = channel
     else
       user.room = null


### PR DESCRIPTION
Hubot was able to join !-channels on ircnet, but couldn't respond
to any messages. This adds (escaped) ! to the regex.
