### PR TITLE
Allow enabling of sasl

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "irc": "lornajane/node-irc#freenode-sasl",
+    "irc": "0.4.1",
     "log": "1.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "irc": "^0.4.0",
+    "irc": "lornajane/node-irc#freenode-sasl",
     "log": "1.4.0"
   },
   "devDependencies": {

--- a/src/irc.coffee
+++ b/src/irc.coffee
@@ -183,6 +183,7 @@ class IrcBot extends Adapter
       certExpired: options.certExpired
       floodProtection: @unfloodProtection(options.unflood),
       floodProtectionDelay: @unfloodProtectionDelay(options.unflood),
+      sasl: true
 
     client_options['channels'] = options.rooms unless options.nickpass
 


### PR DESCRIPTION
Background to the problem I'm solving here: today I realised my hubots, which run on heroku in the european zone, were no longer able to connect to freenode.  This is because the IP range has been blacklisted and freenode has therefore enabled sasl for it.  This module depdends on the node-irc library, which I have also send a related pull request to (https://github.com/martynsmith/node-irc/pull/442) which is why my package.json has a stupid dependency in it - I'll update this if/when it gets accepted.

So the actual change is just to enable sasl so it will be used if it's available!  I'm not a js developer at all so let me know if I've done anything awful that needs changing...
