### PR TITLE
Downgrade logs package to follow hubot logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "irc": "matrix-org/node-irc",
-    "log": "6.0.0"
+    "log": "1.4.0"
   },
   "devDependencies": {
     "are-we-there-yet": "1.1.5",


### PR DESCRIPTION
`ERROR TypeError: logger.info is not a function`

There are 2 different versions of the package `log` since the latest upgrade of the dependencies and the hubot project: https://github.com/hubotio/hubot/blob/master/package.json#L24 vs https://github.com/nandub/hubot-irc/blob/master/package.json#L24

When having both running together I get this error:
```
[Tue Mar 17 2020 18:06:08 GMT+0000 (Greenwich Mean Time)] ERROR TypeError: logger.info is not a function
  at Client.<anonymous> (PATH/node_modules/hubot-irc/src/irc.coffee:310:7, <js>:399:16)
  at Client.emit (events.js:200:13)
  at Client.<anonymous> (PATH/node_modules/irc/lib/irc.js:548:22)
  at Client.emit (events.js:200:13)
  at iterator (PATH/node_modules/irc/lib/irc.js:936:26)
  at Array.forEach (<anonymous>:null:null)
  at TLSSocket.<anonymous> (PATH/node_modules/irc/lib/irc.js:931:15)
  at TLSSocket.emit (events.js:200:13)
  at addChunk (_stream_readable.js:294:12)
  at readableAddChunk (_stream_readable.js:271:13)
  at TLSSocket.Readable.push (_stream_readable.js:210:10)
  at TLSWrap.onStreamRead (internal/stream_base_commons.js:166:17)
```

To fix it I downgraded to the same version the hubot uses and it fixes the issue :smile: 